### PR TITLE
feat: add possibility to make offer from a contract with EIP-1271

### DIFF
--- a/src/gondi.ts
+++ b/src/gondi.ts
@@ -71,7 +71,7 @@ export class Gondi {
 
     const offerInput = {
       ...offer,
-      lenderAddress: this.wallet.account?.address,
+      lenderAddress: offer.lenderAddress ? offer.lenderAddress : this.wallet.account?.address,
       signerAddress: this.wallet.account?.address,
       borrowerAddress: offer.borrowerAddress ?? zeroAddress,
       requiresLiquidation: !!offer.requiresLiquidation,
@@ -130,7 +130,7 @@ export class Gondi {
 
     const offerInput = {
       ...offer,
-      lenderAddress: this.wallet.account?.address,
+      lenderAddress: offer.lenderAddress ? offer.lenderAddress : this.wallet.account?.address,
       signerAddress: this.wallet.account?.address,
       borrowerAddress: offer.borrowerAddress ?? zeroAddress,
       requiresLiquidation: !!offer.requiresLiquidation,


### PR DESCRIPTION
In order to lend from a contract, one needs to have the possibility to make an offer from an address that might not match the signer.