### PR TITLE
feat: refactor examples launch.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "arcanis.vscode-zipfs",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "rioj7.command-variable"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,201 +5,62 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "run example",
+      "preLaunchTask": "build",
       "type": "node",
       "request": "launch",
-      "name": "Launch Program",
-      "skipFiles": ["<node_internals>/**"],
-      "program": "${workspaceFolder}/dist/index.mjs",
-      "outFiles": ["${workspaceFolder}/**/*.js"]
-    },
-    {
-      "name": "add new tranche",
-      "request": "launch",
       "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test addTranche.ts",
-      "type": "node-terminal"
-    },
+      "program": "${input:example}.ts",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["tsx"],
+      "console": "integratedTerminal"
+    }
+  ],
+  "inputs": [
     {
-      "name": "cancel all offers",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test cancelAllOffers.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "cancel offer",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test cancelOffer.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "cancel refinance offer",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test cancelRefinanceOffer.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "delegate and revoke",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test delegateAndRevoke.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "delegate and revoke all",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test delegateAndRevokeAll.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "emit single NFT offer loan",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test emitSingleNFTOfferLoan.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "emit collection offer loan",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test emitCollectionOfferLoan.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "emit multiple offers loan",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test emitMultipleOffersLoan.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "hide offer",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test hideOffer.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "liquidate loan",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test liquidateLoan.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "list listings",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test listListings.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "list loans",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test listLoans.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "list offers",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test listOffers.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "make offer",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test makeOffers.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "refinance batch",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test refinanceBatch.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "refinance from offer",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test refinanceFromOffer.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "refinance full after extend loan",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test refinanceFullAfterExtend.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "refinance full loan",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test refinanceFullLoan.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "refinance partial loan",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test refinancePartialLoan.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "refinance partial multiple tranches loan",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test refinancePartialMultipleTranchesLoan.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "renegotiate loan",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test renegotiateLoan.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "revoke delegations and emit loan",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test revokeDelegationsAndEmitLoan.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "send loan to auction and bid (pre v3)",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test sendLoanToAuctionAndBidPreV3.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "send loan to auction and bid",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test sendLoanToAuctionAndBid.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "user vault creation, deposit, burn and withdraw",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test userVaults.ts",
-      "type": "node-terminal"
-    },
-    {
-      "name": "settle auction with buyout",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/examples",
-      "command": "yarn run-test settleAuctionWithBuyout.ts",
-      "type": "node-terminal"
+      "id": "example",
+      "type": "command",
+      "command": "extension.commandvariable.pickStringRemember",
+      "args": {
+        "key": "example",
+        "description": "Select the test example to run",
+        "options": [
+          { "label": "Last run (${remember:example})", "value": "${remember:example}" },
+          { "label": "Add New Tranche", "value": "addTranche" },
+          { "label": "Cancel All Offers", "value": "cancelAllOffers" },
+          { "label": "Cancel Offer", "value": "cancelOffer" },
+          { "label": "Cancel Refinance Offer", "value": "cancelRefinanceOffer" },
+          { "label": "Delegate and Revoke", "value": "delegateAndRevoke" },
+          { "label": "Delegate and Revoke All", "value": "delegateAndRevokeAll" },
+          { "label": "Emit Single NFT Offer Loan", "value": "emitSingleNFTOfferLoan" },
+          { "label": "Emit Collection Offer Loan", "value": "emitCollectionOfferLoan" },
+          { "label": "Emit Multiple Offers Loan", "value": "emitMultipleOffersLoan" },
+          { "label": "Hide Offer", "value": "hideOffer" },
+          { "label": "Liquidate Loan", "value": "liquidateLoan" },
+          { "label": "List Listings", "value": "listListings" },
+          { "label": "List Loans", "value": "listLoans" },
+          { "label": "List Offers", "value": "listOffers" },
+          { "label": "Make Offer", "value": "makeOffers" },
+          { "label": "Refinance Batch", "value": "refinanceBatch" },
+          { "label": "Refinance From Offer", "value": "refinanceFromOffer" },
+          { "label": "Refinance Full After Extend Loan", "value": "refinanceFullAfterExtend" },
+          { "label": "Refinance Full Loan", "value": "refinanceFullLoan" },
+          { "label": "Refinance Partial Loan", "value": "refinancePartialLoan" },
+          {
+            "label": "Refinance Partial Multiple Tranches Loan",
+            "value": "refinancePartialMultipleTranchesLoan"
+          },
+          { "label": "Renegotiate Loan", "value": "renegotiateLoan" },
+          { "label": "Revoke Delegations and Emit Loan", "value": "revokeDelegationsAndEmitLoan" },
+          {
+            "label": "Send Loan to Auction and Bid (pre v3)",
+            "value": "sendLoanToAuctionAndBidPreV3"
+          },
+          { "label": "Send Loan to Auction and Bid", "value": "sendLoanToAuctionAndBid" },
+          { "label": "User Vault Creation, Deposit, Burn and Withdraw", "value": "userVaults" },
+          { "label": "Settle Auction with Buyout", "value": "settleAuctionWithBuyout" }
+        ]
+      }
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,10 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "yarn build"
+        }
+    ]
+}


### PR DESCRIPTION
Refactored to have only one launch target. 
It will pop a pick to select which example run, and it will remember last choice.
It's necessary to install vscode extension.