### PR TITLE
chore(ci): move bun audit into scheduled workflow

### DIFF
--- a/.github/audit/ignored-cves
+++ b/.github/audit/ignored-cves
@@ -1,0 +1,8 @@
+# GHSA IDs to suppress in scheduled dependency audits.
+# Format: one GHSA ID per line. Lines starting with `#` are comments and
+# the most recent comment is shown as the "Reason" for the next ID in the
+# auto-managed security issue.
+#
+# Example:
+#   # webpack — pinned by transitive dep, no fix available
+#   GHSA-8fgc-7cc6-rx7x

--- a/.github/audit/issue-body.md
+++ b/.github/audit/issue-body.md
@@ -1,0 +1,18 @@
+## Dependency audit failed on `{{BRANCH}}`
+
+**Workflow run**: {{RUN_URL}}
+**Date**: {{DATE}}
+
+### Audit output
+
+```
+{{AUDIT_OUTPUT}}
+```
+
+### Ignored CVEs
+
+{{IGNORED_CVES_TABLE}}
+
+---
+
+_This issue is updated automatically by the [scheduled audit workflow]({{RUN_URL}})._

--- a/.github/scripts/audit-report.sh
+++ b/.github/scripts/audit-report.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Manages GitHub Issues for scheduled dependency audit results.
+# Called by .github/workflows/scheduled-audit.yaml after bun audit runs.
+#
+# Required env vars:
+#   BRANCH          — branch that was audited (e.g. "main")
+#   AUDIT_OUTPUT    — full stdout/stderr from bun audit
+#   AUDIT_EXIT_CODE — exit code from bun audit (0 = clean, non-zero = vulnerabilities)
+#
+# Uses GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID from the runner.
+
+set -euo pipefail
+
+LABEL="security"
+BRANCH_LABEL="audit:${BRANCH}"
+TITLE="Security: dependency vulnerabilities found on \`${BRANCH}\`"
+RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+DATE=$(date -u +%Y-%m-%d)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+AUDIT_DIR="${SCRIPT_DIR}/../audit"
+
+ensure_labels() {
+  gh label create "$LABEL" --color d73a4a --description "Security vulnerability" --force 2>/dev/null || true
+  gh label create "$BRANCH_LABEL" --color 0075ca --description "Audit findings for ${BRANCH} branch" --force 2>/dev/null || true
+}
+
+find_open_issue() {
+  gh issue list --label "$LABEL,$BRANCH_LABEL" --state open --limit 1 --json number --jq '.[0].number // empty'
+}
+
+build_ignored_cves_table() {
+  local ignore_file="${AUDIT_DIR}/ignored-cves"
+  echo "| CVE | Reason |"
+  echo "|-----|--------|"
+  local reason=""
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^#\ (.+) ]]; then
+      reason="${BASH_REMATCH[1]}"
+    elif [[ -n "$line" && ! "$line" =~ ^# ]]; then
+      echo "| ${line} | ${reason} |"
+    fi
+  done < "$ignore_file"
+}
+
+build_issue_body() {
+  local template
+  template=$(<"${AUDIT_DIR}/issue-body.md")
+  local ignored_table
+  ignored_table=$(build_ignored_cves_table)
+
+  template="${template//\{\{BRANCH\}\}/$BRANCH}"
+  template="${template//\{\{RUN_URL\}\}/$RUN_URL}"
+  template="${template//\{\{DATE\}\}/$DATE}"
+  template="${template//\{\{IGNORED_CVES_TABLE\}\}/$ignored_table}"
+  template="${template//\{\{AUDIT_OUTPUT\}\}/$AUDIT_OUTPUT}"
+
+  printf '%s\n' "$template"
+}
+
+if [[ "$AUDIT_EXIT_CODE" != "0" ]]; then
+  echo "Vulnerabilities found on ${BRANCH}, managing issue..."
+  ensure_labels
+
+  BODY=$(build_issue_body)
+  EXISTING=$(find_open_issue)
+
+  if [[ -n "$EXISTING" ]]; then
+    gh issue edit "$EXISTING" --body "$BODY"
+    echo "Updated existing issue #${EXISTING}"
+  else
+    NEW_ISSUE=$(gh issue create --title "$TITLE" --body "$BODY" --label "$LABEL,$BRANCH_LABEL")
+    echo "Created issue: ${NEW_ISSUE}"
+  fi
+else
+  echo "No vulnerabilities on ${BRANCH}, checking for open issues to close..."
+  EXISTING=$(find_open_issue)
+
+  if [[ -n "$EXISTING" ]]; then
+    gh issue close "$EXISTING" --comment "All vulnerabilities resolved as of ${DATE}. Closing.
+
+[Workflow run](${RUN_URL})"
+    echo "Closed resolved issue #${EXISTING}"
+  else
+    echo "No open issue to close."
+  fi
+fi

--- a/.github/scripts/run-audit.sh
+++ b/.github/scripts/run-audit.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Runs `bun audit` with the project's ignored CVE list and emits results
+# to GITHUB_OUTPUT for downstream steps.
+#
+# Reads ignored CVEs from .github/audit/ignored-cves (one GHSA ID per line, # comments allowed).
+# Sets outputs:
+#   exit_code — bun audit exit code
+#   output    — full stdout/stderr from bun audit
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+IGNORE_FILE="${SCRIPT_DIR}/../audit/ignored-cves"
+
+IGNORE_FLAGS=()
+while IFS= read -r line; do
+  if [[ -n "$line" && ! "$line" =~ ^# ]]; then
+    IGNORE_FLAGS+=("--ignore=${line}")
+  fi
+done < "$IGNORE_FILE"
+
+AUDIT_OUTPUT=$(bun audit "${IGNORE_FLAGS[@]}" 2>&1)
+AUDIT_EXIT=$?
+
+echo "exit_code=$AUDIT_EXIT" >> "$GITHUB_OUTPUT"
+{
+  echo "output<<AUDIT_EOF"
+  echo "$AUDIT_OUTPUT"
+  echo "AUDIT_EOF"
+} >> "$GITHUB_OUTPUT"
+
+if [ $AUDIT_EXIT -ne 0 ]; then
+  echo "::warning::Vulnerabilities found"
+else
+  echo "No new vulnerabilities found"
+fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,6 +24,3 @@ jobs:
 
       - name: Verify
         run: bun run verify
-
-      - name: Security Audit
-        run: bun audit

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,9 +33,6 @@ jobs:
       - name: Verify
         run: bun run verify
 
-      - name: Security Audit
-        run: bun audit
-
       - name: Set package.json version as env
         run: node -p -e '`PACKAGE_VERSION=${require("./package.json").version}`' >> $GITHUB_ENV
 

--- a/.github/workflows/scheduled-audit.yaml
+++ b/.github/workflows/scheduled-audit.yaml
@@ -1,0 +1,60 @@
+name: Scheduled dependency audit
+
+on:
+  schedule:
+    # Twice daily: 9:30 AM UTC and 5:00 PM UTC
+    - cron: '30 9 * * *'
+    - cron: '0 17 * * *'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    name: Audit (${{ matrix.branch }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+      contents: read
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.branch }}
+      cancel-in-progress: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ['main']
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            ./node_modules
+          key: ${{ runner.os }}-bun-cache-${{ matrix.branch }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-cache-${{ matrix.branch }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run audit
+        id: audit
+        continue-on-error: true
+        run: .github/scripts/run-audit.sh
+
+      - name: Report audit results
+        env:
+          BRANCH: ${{ matrix.branch }}
+          AUDIT_OUTPUT: ${{ steps.audit.outputs.output }}
+          AUDIT_EXIT_CODE: ${{ steps.audit.outputs.exit_code }}
+          GH_TOKEN: ${{ github.token }}
+        run: .github/scripts/audit-report.sh


### PR DESCRIPTION
## Summary

- Removes the `Security Audit` step from `lint.yaml` and `main.yaml` so PR/release CI is no longer coupled to the live npm advisory database (a brand-new advisory against an existing transitive dep currently blocks unrelated PRs and the npm publish pipeline).
- Adds a dedicated `scheduled-audit.yaml` workflow that runs `bun audit` twice daily (09:30 / 17:00 UTC) plus on `workflow_dispatch`. It manages a single security GitHub Issue per branch — creates one when vulnerabilities appear, updates it on subsequent runs, and auto-closes it when resolved.
- Audit logic split into two checked-in shell scripts (`.github/scripts/run-audit.sh`, `.github/scripts/audit-report.sh`) so the YAML stays minimal and the logic is reviewable. Suppressed CVEs live in `.github/audit/ignored-cves` (one GHSA per line, `# comments` become reasons in the issue body) and the issue template lives in `.github/audit/issue-body.md` — both editable without touching workflow YAML.
- Ported from [pixeldaogg/frontend@a797399](https://github.com/pixeldaogg/frontend/commit/a79273997e625ff804ffa6417350514e9fccab79). Adaptations for gondi-js: matrix collapses to `['main']` (no `develop` branch), uses `oven-sh/setup-bun@v1` + `bun-version: latest` to match existing workflows, no `package.json` bump (CI-only change).
- **Bug fix vs. upstream**: the reference `audit-report.sh` interpolates `$AUDIT_OUTPUT` into the issue body via `awk -v output="$AUDIT_OUTPUT"`, which crashes whenever the output contains newlines (`awk: newline in string ...`) — i.e. always. Replaced with bash parameter expansion (matching the other `{{PLACEHOLDER}}` substitutions in the same function).
- `AUDIT_OUTPUT` is passed to `audit-report.sh` via `env:`, never interpolated into a `run:` block, so advisory text can't be used for shell injection.

## First-run expectation

`.github/audit/ignored-cves` ships empty. `bun audit` currently flags 2 lodash advisories (`GHSA-r5fr-rjxr-66jc`, `GHSA-f23m-r3pf-42rh`) coming from `@graphql-codegen/*` dev dependencies, so the first scheduled run on `main` will open one security issue listing them. From there: triage and either suppress them in `.github/audit/ignored-cves` with a comment explaining why, or bump the dev tooling.

## Test plan

- [x] Local: `bun run lint` clean (pre-commit hook also passed)
- [x] Local: `run-audit.sh` correctly emits `exit_code` + multi-line `output<<AUDIT_EOF` block to a temp `GITHUB_OUTPUT`
- [x] Local: `audit-report.sh` dry-run with stubbed `gh` covers all three paths — vulns + no existing issue (creates), clean + no open issue (no-op), populated `ignored-cves` table (reason inheritance from `# comment` lines works)
- [ ] Post-merge: `gh workflow run scheduled-audit.yaml` to trigger manually and confirm the security issue is opened with the correct body
- [ ] Post-merge: confirm that `lint` and `main` workflow runs no longer contain a `Security Audit` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)