### PR TITLE
chore(ci): pin bun to 1.3.12 across all workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/scheduled-audit.yaml
+++ b/.github/workflows/scheduled-audit.yaml
@@ -30,9 +30,9 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - uses: actions/cache@v4
         with:

--- a/package.json
+++ b/package.json
@@ -93,5 +93,5 @@
     "yaml": "1.10.3",
     "yargs-parser": "5.0.1"
   },
-  "packageManager": "bun@1.3.1"
+  "packageManager": "bun@1.3.12"
 }


### PR DESCRIPTION
## Summary

- All three workflows (`lint.yaml`, `main.yaml`, `scheduled-audit.yaml`) were using `oven-sh/setup-bun@v1` with `bun-version: latest`, which silently drifts whenever Oven ships a new bun release. This makes audit and install results non-reproducible — a brand-new bun release can change what `bun audit` reports without any repo change, and CI can start or stop failing unrelated to the diff being tested.
- The `packageManager` field already existed in `package.json` but was pointed at an older version (`bun@1.3.1`) and was ignored by every workflow. Bump it to `bun@1.3.12` (the version `latest` currently resolves to — so this preserves existing CI behavior) and switch all three workflows to `setup-bun@v2` + `bun-version-file: package.json` so the pinned version is now the single source of truth for both devs (via corepack / documentation) and CI.
- Matches the pattern already used in [pixeldaogg/frontend](https://github.com/pixeldaogg/frontend/blob/main/.github/workflows/scheduled-audit.yaml).

## Note on the audit discrepancy

This PR was prompted by observing that `bun audit v1.3.6` (local) reports 2 lodash advisories coming from `@graphql-codegen/*` dev transitives, while `bun audit v1.3.12` (CI, via `latest`) reports clean — for the same `bun.lock`. See the first scheduled run: gondixyz/gondi-js/actions/runs/24260571242.

This PR **pins to 1.3.12**, which is what CI was already using implicitly via `latest`. It does **not** explain or fix the underlying audit delta — that should be investigated separately. Candidates to look at:

- bun 1.3.12 may now honor the `"lodash": "4.18.0"` override in `package.json:88` differently from 1.3.6 (although `4.18.0` is not a real lodash version, which itself is suspect).
- bun 1.3.12 may have changed how `bun audit` walks dev-only transitive dependencies.
- bun 1.3.12 may filter advisories differently by default.

Pinning makes both results reproducible, which is a prerequisite for that investigation.

## Test plan

- [x] Local: `bun run lint` clean
- [x] Local: pre-commit hook passes
- [ ] Post-merge: watch the first `main` push — `Lint` and `Main` workflows should install and pass against bun 1.3.12 (same as today, since `latest` already resolves there)
- [ ] Post-merge: trigger `gh workflow run scheduled-audit.yaml` and confirm the audit step still runs on 1.3.12 (result: currently clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)