### PR TITLE
Allow provided SIWE issuedAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# Bug Fixes 0.29.15
+
+### Important
+
+---
+
+This document outlines the changes introduced in our codebase for version 0.29.15.
+
+## Table of Contents
+
+- [Configurable SIWE `issuedAt`](#configurable-siwe-issuedat-02915) allow callers to provide a server-issued timestamp for sign-in messages
+
+---
+
+## Configurable SIWE `issuedAt` 0.29.15
+
+**Description:**
+
+- ENHANCEMENT: `buildSiweMessage` now accepts an optional `issuedAt` timestamp. When provided, the SIWE message uses that timestamp instead of reading the local client clock.
+- ENHANCEMENT: The SDK `signIn` helper accepts and forwards the optional `issuedAt` timestamp to `buildSiweMessage`. Existing callers keep the previous behavior when the argument is omitted.
+
+---
+
 # Bug Fixes 0.29.14
 
 ### Important

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gondi",
-  "version": "0.29.14",
+  "version": "0.29.15",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.mjs",

--- a/src/clients/api/auth.ts
+++ b/src/clients/api/auth.ts
@@ -35,7 +35,7 @@ export const getAuthClient = async () => {
   });
 };
 
-export const signIn = async ({ wallet }: { wallet: Wallet }) => {
+export const signIn = async ({ wallet, issuedAt }: { wallet: Wallet; issuedAt?: string }) => {
   const authClient = await getAuthClient();
 
   const { data, errors } = await authClient.mutate({
@@ -64,6 +64,7 @@ export const signIn = async ({ wallet }: { wallet: Wallet }) => {
     uri: authApiUrl(),
     version: '1',
     nonce,
+    issuedAt,
   });
 
   const signature = await wallet.signMessage({

--- a/src/clients/api/siwe.ts
+++ b/src/clients/api/siwe.ts
@@ -8,6 +8,7 @@ export const buildSiweMessage = ({
   version,
   chainId,
   nonce,
+  issuedAt,
 }: {
   domain: string;
   address: string;
@@ -16,12 +17,13 @@ export const buildSiweMessage = ({
   version: string;
   chainId: number;
   nonce: string;
+  issuedAt?: string;
 }): string => {
   const checksummed = getAddress(address);
   if (checksummed !== address) {
     throw new Error(`Address must be EIP-55 checksummed: ${address}`);
   }
-  const issuedAt = new Date().toISOString();
+  const messageIssuedAt = issuedAt ?? new Date().toISOString();
   return (
     `${domain} wants you to sign in with your Ethereum account:\n` +
     `${checksummed}\n\n` +
@@ -30,6 +32,6 @@ export const buildSiweMessage = ({
     `Version: ${version}\n` +
     `Chain ID: ${chainId}\n` +
     `Nonce: ${nonce}\n` +
-    `Issued At: ${issuedAt}`
+    `Issued At: ${messageIssuedAt}`
   );
 };

--- a/tests/clients/api/auth.test.ts
+++ b/tests/clients/api/auth.test.ts
@@ -29,6 +29,24 @@ describe('buildSiweMessage', () => {
     expect(ours).toBe(expected);
   });
 
+  test('uses a provided issuedAt timestamp', () => {
+    const params = {
+      domain: 'gondi.xyz',
+      address: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+      statement: 'Sign in with Ethereum to the app.',
+      uri: 'https://api.gondi.xyz/lending/graphql',
+      version: '1',
+      chainId: 1,
+      nonce: 'abcdef1234567890',
+      issuedAt: '2026-05-01T09:30:00.000Z',
+    };
+
+    const ours = buildSiweMessage(params);
+    const expected = new SiweMessage(params).prepareMessage();
+
+    expect(ours).toBe(expected);
+  });
+
   test.each([
     [1, '00000000', '0x71C7656EC7ab88b098defB751B7401B5f6d8976F'],
     [137, 'ffffffff', '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'],


### PR DESCRIPTION
## Summary
- allow `buildSiweMessage` to accept an optional `issuedAt` timestamp
- allow SDK `signIn` to forward a provided `issuedAt`
- bump package version to `0.29.15` and add a changelog entry

## Checks
- `HUSKY=0 bun install --frozen-lockfile`
- `bun test tests/clients/api/auth.test.ts`
- `bun run fmt-check -- CHANGELOG.md package.json src/clients/api/siwe.ts src/clients/api/auth.ts tests/clients/api/auth.test.ts`
- `git diff --check`