### PR TITLE
feat: add transferNFT method to send an NFT to another wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+# New Features 0.30.0
+
+### Important
+
+---
+
+This document outlines the changes introduced in our codebase for version 0.30.0.
+
+## Table of Contents
+
+- [NFT Transfer](#nft-transfer-0300) new `transferNFT` method to send an NFT to another wallet
+
+---
+
+## NFT Transfer 0.30.0
+
+**Description:**
+
+- NEW: `transferNFT` transfers an NFT owned by the connected wallet to another wallet. It supports `ERC721` (default), `ERC1155`, naked `CryptoPunks` (`transferPunk`) and old pre-ERC721 collections (`OldERC721`). The write is simulated before broadcasting and the returned `waitTxInBlock` resolves with the parsed transfer event and the receipt.
+
+```typescript
+const { txHash, waitTxInBlock } = await gondi.transferNFT({
+  to: '0xRecipient',
+  nftAddress: '0xCollection',
+  tokenId: 1n,
+});
+const result = await waitTxInBlock();
+```
+
+---
+
 # Bug Fixes 0.29.15
 
 ### Important

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "gondi",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gondi",
-  "version": "0.29.15",
+  "version": "0.30.0",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.mjs",

--- a/src/clients/contracts/index.ts
+++ b/src/clients/contracts/index.ts
@@ -184,6 +184,14 @@ export class Contracts {
     });
   }
 
+  Cryptopunks(address: Address) {
+    return new BaseContract({
+      address,
+      abi: cryptopunksABI,
+      walletClient: this.walletClient,
+    });
+  }
+
   ERC1155(address: Address) {
     return new BaseContract({
       address,

--- a/src/gondi.ts
+++ b/src/gondi.ts
@@ -7,6 +7,7 @@ import {
   createTransport,
   Hash,
   Hex,
+  TransactionReceipt,
   TypedDataDefinition,
 } from 'viem';
 import { getAddress } from 'viem';
@@ -1033,6 +1034,66 @@ export class Gondi {
         return { ...events[0].args, ...receipt };
       },
     };
+  }
+
+  /**
+   * Transfer an NFT to another wallet. The sender is the connected wallet account.
+   * Supports ERC721 (default), ERC1155, naked CryptoPunks and old (pre-ERC721) collections.
+   * `amount` only applies to ERC1155 transfers.
+   */
+  async transferNFT({
+    to,
+    nftAddress,
+    tokenId,
+    standard = 'ERC721',
+    amount = 1n,
+  }: {
+    to: Address;
+    nftAddress: Address;
+    tokenId: bigint;
+    standard?: model.TransferNftStandard;
+    amount?: bigint;
+  }) {
+    const from = this.wallet.account.address;
+    const buildTransferResult = <TEventArgs extends object>(
+      txHash: Hash,
+      getTransferEvents: (logs: TransactionReceipt['logs']) => { args: TEventArgs }[],
+    ) => ({
+      txHash,
+      waitTxInBlock: async () => {
+        const receipt = await this.bcClient.waitForTransactionReceipt({ hash: txHash });
+        const events = getTransferEvents(receipt.logs);
+        if (events.length === 0) throw new Error(`${standard} transfer failed`);
+        return { ...events[0].args, ...receipt };
+      },
+    });
+
+    if (standard === 'ERC1155') {
+      const nft = this.contracts.ERC1155(nftAddress);
+      const txHash = await nft.safeContractWrite.safeTransferFrom([
+        from,
+        to,
+        tokenId,
+        amount,
+        zeroHex,
+      ]);
+      return buildTransferResult(txHash, (logs) => nft.parseEventLogs('TransferSingle', logs));
+    }
+    if (standard === 'CryptoPunks') {
+      const cryptopunks = this.contracts.Cryptopunks(nftAddress);
+      const txHash = await cryptopunks.safeContractWrite.transferPunk([to, tokenId]);
+      return buildTransferResult(txHash, (logs) =>
+        cryptopunks.parseEventLogs('PunkTransfer', logs),
+      );
+    }
+    if (standard === 'OldERC721') {
+      const nft = this.contracts.OldERC721(nftAddress);
+      const txHash = await nft.safeContractWrite.transfer([to, tokenId]);
+      return buildTransferResult(txHash, (logs) => nft.parseEventLogs('Transfer', logs));
+    }
+    const nft = this.contracts.ERC721(nftAddress);
+    const txHash = await nft.safeContractWrite.safeTransferFrom([from, to, tokenId]);
+    return buildTransferResult(txHash, (logs) => nft.parseEventLogs('Transfer', logs));
   }
 
   async isApprovedToken({

--- a/src/model.ts
+++ b/src/model.ts
@@ -119,3 +119,5 @@ export type ListListingsProps = {
 };
 
 export type NftStandard = 'ERC721' | 'ERC1155';
+
+export type TransferNftStandard = NftStandard | 'CryptoPunks' | 'OldERC721';


### PR DESCRIPTION
## Summary

Adds a public `Gondi.transferNFT` method so SDK consumers can send an NFT owned by the connected wallet to another wallet. It supports `ERC721` (default), `ERC1155`, naked `CryptoPunks` (via `transferPunk`) and old pre-ERC721 collections (via their legacy `transfer`). Bumps the package to `0.30.0`.

Mirror of the same change already merged in the internal monorepo (pixeldaogg/gondi#530); it powers the upcoming "Transfer Item" flow on the item profile.

## Changes

- `src/gondi.ts`: new `transferNFT({ to, nftAddress, tokenId, standard, amount })` branching per standard: ERC721 `safeTransferFrom(from, to, tokenId)` (3-arg overload), ERC1155 `safeTransferFrom(..., amount, 0x)`, CryptoPunks `transferPunk(to, punkIndex)`, OldERC721 `transfer(to, tokenId)`; parses `Transfer` / `TransferSingle` / `PunkTransfer` accordingly. Follows the `approveNFTForAll` shape: `safeContractWrite` (simulate-then-broadcast) returning `{ txHash, waitTxInBlock }`, where `waitTxInBlock` resolves with the parsed transfer event plus the receipt.
- `src/clients/contracts/index.ts`: new `Contracts.Cryptopunks(address)` helper (typed `cryptopunksABI` wrapper, mirrors `OldERC721`).
- `src/model.ts`: new exported `TransferNftStandard` type (`NftStandard | 'CryptoPunks' | 'OldERC721'`).
- `package.json` `0.29.15` → `0.30.0` + `CHANGELOG.md` entry.

No ABI regeneration needed — all four ABIs already exist in `src/generated/blockchain/`.

```typescript
const { txHash, waitTxInBlock } = await gondi.transferNFT({
  to: '0xRecipient',
  nftAddress: '0xCollection',
  tokenId: 1n,
});
const result = await waitTxInBlock();
```

Validated with `bun run build`, `bun run lint`, and `bun test` (20 tests pass).
