### PR TITLE
fix: correct the anvil UserVault fallback and resolve env overrides per call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# Bug Fixes 0.30.1
+
+### Important
+
+---
+
+This document outlines the changes introduced in our codebase for version 0.30.1.
+
+## Table of Contents
+
+- [Anvil UserVault address](#anvil-uservault-address-0301) corrected stale fallback and per-call environment resolution
+
+---
+
+## Anvil UserVault address 0.30.1
+
+**Description:**
+
+- FIX: the anvil fallback address for `UserVault` version `3` pointed at a contract that is no longer the vault on dev chains (`0x4A67…`), so `createUserVault` reverted on `mint`. It now defaults to the deployed dev vault (`0x0963…`).
+- FIX: `getContracts` builds its per-chain table on every call, so `GONDI_*` environment overrides set by the host application at any point (for example `GONDI_USER_VAULT_V6`) are honored instead of being snapshotted at module load.
+
+---
+
 # New Features 0.30.0
 
 ### Important

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gondi",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.mjs",

--- a/src/deploys.ts
+++ b/src/deploys.ts
@@ -55,7 +55,12 @@ const ensureAddress = (value: string | undefined): Address | null => {
 export const MSL_V5_TX_HASH =
   '0xb6dfcbc1661d0c0bced9591d06e964f97d41a35984704ffe61f8e062e43919c8' as Hash;
 
-const contractsByChain: Record<number, Contracts> = {
+/**
+ * Built per call so the GONDI_* environment overrides are read when contracts
+ * are needed instead of being snapshotted at module load, which runs before
+ * host apps can populate them.
+ */
+const buildContractsByChain = (): Record<number, Contracts> => ({
   [ANVIL_CHAIN_ID]: {
     MultiSourceLoan: {
       '1':
@@ -91,7 +96,7 @@ const contractsByChain: Record<number, Contracts> = {
         '0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82',
       '3':
         ensureAddress(process.env.GONDI_USER_VAULT_V6) ??
-        '0x4A679253410272dd5232B3Ff7cF5dbB88f295319',
+        '0x09635F643e140090A9A8Dcd712eD6285858ceBef',
     },
     PurchaseBundler: {
       '2':
@@ -167,10 +172,10 @@ const contractsByChain: Record<number, Contracts> = {
     Aave: zeroAddress,
     Cryptopunks: zeroAddress,
   },
-};
+});
 
 export const getContracts = (chain: Pick<Chain, 'id'>): Contracts => {
-  const contracts = contractsByChain[chain.id];
+  const contracts = buildContractsByChain()[chain.id];
   if (!contracts) {
     throw new Error(`No contracts found for chain ${chain.id}`);
   }


### PR DESCRIPTION
## Summary

Fixes `createUserVault` reverting on `mint` on anvil dev chains: the SDK resolved the UserVault `'3'` address to a stale fallback (`0x4A679253410272dd5232B3Ff7cF5dbB88f295319`) where a different contract now lives, so the call reverted with `Contract does not have fallback nor receive functions`. Deposits into existing vaults hit the same table through `getVersionFromUserVaultAddress` and threw `No version found`. Bumps the package to `0.30.1`.

Mirror of the same change already merged in the internal monorepo (pixeldaogg/gondi#770).

## Root cause

The fallback was set in #97 (Nov 2024) and was correct at the time; the dev vault later moved to `0x09635F643e140090A9A8Dcd712eD6285858ceBef`. That stayed harmless while `getContracts` built its table inside the function — `process.env.GONDI_*` overrides were read at call time, after host applications had assigned them. #156 (multichain config) hoisted the table to a module-level `contractsByChain` constant, moving the env reads to module-evaluation time; hosts that populate the overrides at runtime evaluate the SDK module first, so the table froze with the stale fallback.

## Changes

- `src/deploys.ts`: `getContracts` builds the per-chain table on every call (`buildContractsByChain()`), restoring the pre-#156 override semantics — `GONDI_*` values assigned by the host at any point are honored instead of being snapshotted at module load. Per-call rather than memoized-on-first-call so no early resolution can ever freeze the table.
- `src/deploys.ts`: the anvil UserVault `'3'` fallback now matches the deployed dev vault (`0x0963…`), covering hosts where no env override is set at all (browser bundles inline `process.env`, so runtime assignment never reaches them).
- `package.json` `0.30.0` → `0.30.1` + `CHANGELOG.md` entry.

Validated with `bun run build`, `bun run lint`, and `bun test` (20 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
