### PR TITLE
fix: surface OpenSea response body in fulfillment errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# Bug Fixes 0.30.2
+
+### Important
+
+---
+
+This document outlines the changes introduced in our codebase for version 0.30.2.
+
+## Table of Contents
+
+- [OpenSea error logging](#opensea-error-logging-0302) surface the OpenSea response body and request path in failed fulfillment errors
+
+---
+
+## OpenSea error logging 0.30.2
+
+**Description:**
+
+- FIX: `Opensea.postApi` discarded OpenSea's response body on non-2xx responses, so `sellNft` failures surfaced only as opaque `OpenSea API error: 400` messages (empty `statusText`, no reason). The thrown error now includes the request path and OpenSea's response body, making stale/invalid-offer rejections diagnosable.
+- FIX: the request URL joined `apiUrl` and `path` with a literal slash while both already carried one, producing a double slash (`/api/v2//offers/...`). The join now trims the boundary slashes.
+
+---
+
 # Bug Fixes 0.30.1
 
 ### Important

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gondi",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.mjs",

--- a/src/clients/opensea/index.ts
+++ b/src/clients/opensea/index.ts
@@ -116,14 +116,19 @@ export class Opensea {
       'x-api-key': this.apiKey || '',
     };
 
-    const response = await fetch(`${this.apiUrl}/${path}`, {
+    const url = `${this.apiUrl.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+    const response = await fetch(url, {
       method: 'POST',
       headers,
       body: body ? JSON.stringify(body) : undefined,
     });
 
     if (!response.ok) {
-      throw new Error(`OpenSea API error: ${response.status} ${response.statusText}`);
+      const detail = await response.text().catch(() => '');
+      const suffix = detail ? ` - ${detail}` : '';
+      throw new Error(
+        `OpenSea API error: ${response.status} ${response.statusText} (POST ${path})${suffix}`,
+      );
     }
 
     return response.json();


### PR DESCRIPTION
Opensea.postApi discarded OpenSea's response body on non-2xx responses, so sellNft failures surfaced only as opaque "OpenSea API error: 400" messages (empty statusText, no reason). The thrown error now includes the request path and OpenSea's response body, making stale/invalid-offer rejections diagnosable.

Also trims the boundary slashes when joining apiUrl and path, removing the double slash in /api/v2//offers/...

Mirror of pixeldaogg/gondi#840.