### PR TITLE
chore: bump bun to 1.3.14

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "gondi",

--- a/package.json
+++ b/package.json
@@ -94,5 +94,5 @@
     "yaml": "1.10.3",
     "yargs-parser": "5.0.1"
   },
-  "packageManager": "bun@1.3.12"
+  "packageManager": "bun@1.3.14"
 }


### PR DESCRIPTION
## Summary

Bump the Bun toolchain pin from 1.3.12 to 1.3.14. No code changes — CI's `setup-bun` steps read the version from `package.json` (`bun-version-file: package.json`), so `main.yaml`, `lint.yaml`, and `scheduled-audit.yaml` follow automatically.

## Context

Bun 1.3.13/1.3.14 are patch releases with no breaking changes, but they bring wins we benefit from directly: faster `bun install` (streaming tarball extraction, ~8.5x faster isolated linker on peer-heavy graphs, global virtual store for warm installs), new test-runner flags (`--parallel`, `--shard`, `--changed`) usable by this repo's `bun test`, and 100+ Node.js-compatibility fixes.

This mirrors pixeldaogg/gondi#845, which bumped the same pin in the monorepo's `frontend/` and `gondi-js/` workspaces.

## Changes

- `package.json`: `packageManager` `bun@1.3.12` → `bun@1.3.14`.
- `bun.lock`: gains `"configVersion": 0` — a lockfile-format normalization 1.3.14 writes. No dependency resolution changes.

Verified locally on 1.3.14: build (esbuild + tsc + tsc-alias), lint, format check, and all 20 tests pass.